### PR TITLE
Make PartMapper practical for Unix-like systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ Double check the @site variable, ensure it points to KerablX.com for production 
     
     ocra kerbalx_part_mapper.rb --no-enc --output 'PartMapper.exe'
     
+
+##Standalone script "compilation"
+For non-Windows platforms (Linux; Mac should work in theory but hasn't been tested) with Ruby installed, a single `PartMapper` executable can be created using the ["mergit"](https://github.com/docwhat/mergit) tool.
+
+    # In your shell...
+    bundle install     # skip if already installed
+    gem install mergit # skip if already installed; might require 'sudo'
+    irb                # the 'mergit' command doesn't work, so we'll do it manually
     
+    # In IRB...
+    require 'mergit'
+    mergit = Mergit.new(:search_path => [ './lib' ])
+    merged = mergit.process_file('kerbalx_part_mapper.rb')
+    File.open('PartMapper', 'w') { |file| file.write(merged) }
+    exit
     
-    
+    # Back in your shell...
+    chmod +x PartMapper
+    cp PartMapper ignored_mods.txt "~/path/to/Kerbal Space Program" # or wherever
+    cd "~/path/to/Kerbal Space Program"
+    # Grab your KerbalX.key
+    ./PartMapper

--- a/kerbalx_part_mapper.rb
+++ b/kerbalx_part_mapper.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 #This is the script which is compiled into a .exe by OCRA for use in a windows environment that is devoid of ~joy~ Ruby.
 
 


### PR DESCRIPTION
Primarily: add in some instructions for slapping together a combined single Ruby script for use on Linux and (probably; haven't tested it) OS X.

I've tested the added procedure to work fine on Ruby 2.3.x on Slackware.  The resulting executable also seems to work okay (presumably just like PartMapper.exe).

I'm sure similar treatment could be given to `kerbalx_ckan_reader.rb` if it's also intended to be a runnable program.