### PR TITLE
Obey CKAN install stanzas

### DIFF
--- a/spec/lib/KerbalX/ckan_reader_spec.rb
+++ b/spec/lib/KerbalX/ckan_reader_spec.rb
@@ -1,8 +1,65 @@
 require 'spec_helper'
 
 
-describe KerbalX::CkanReader do 
-  before :each do  
+describe KerbalX::InstallStanzas do
+  it 'file should match only installed files' do
+    install = KerbalX::InstallStanzas.new({
+      :install => [{
+        :file => "GameData/TestModule"
+      }]
+    })
+    expect(install.match?("GameData/TestModule")).to be true
+    expect(install.match?("GameData/TestModule/my_patch.cfg")).to be true
+    expect(install.match?("GameData/TestModule/Parts/my_part.cfg")).to be true
+    expect(install.match?("install_instructions.txt")).to be false
+    expect(install.match?("TestModule/bad_path_patch.cfg")).to be false
+    expect(install.match?("GameData/BundledModule/Parts/weird_part.cfg")).to be false
+  end
+  it 'find should match installed files' do
+    install = KerbalX::InstallStanzas.new({
+      :install => [{
+        :find => "TestModule"
+      }]
+    })
+    expect(install.match?("TestModule")).to be true
+    expect(install.match?("TestModule/my_patch.cfg")).to be true
+    expect(install.match?("TestModule/Parts/my_part.cfg")).to be true
+    expect(install.match?("BundledModule/Parts/another_part.cfg")).to be false
+  end
+  it 'find_regexp should match only installed files' do
+    install = KerbalX::InstallStanzas.new({
+      :install => [{
+        :find_regexp => "CoolModule-[0-9.]+"
+      }]
+    })
+    expect(install.match?("CoolModule-1.2.3.4/test_file.txt")).to be true
+    expect(install.match?("CoolModule-asdf/test_file.txt")).to be false
+    expect(install.match?("DumbModule-3.4.5/test_file.txt")).to be false
+  end
+  it 'default stanza should install only identifier-named folder' do
+    install = KerbalX::InstallStanzas.new({
+      :identifier => "MyModule"
+    })
+    expect(install.match?("MyModule/test_patch.cfg")).to be true
+    expect(install.match?("GameData/MyModule/test_patch.cfg")).to be true
+    expect(install.match?("GameData/MyModule/Parts/new_part.cfg")).to be true
+    expect(install.match?("BundledModule/part.cfg")).to be false
+  end
+  it 'should not match filtered files' do
+    install = KerbalX::InstallStanzas.new({
+      :install => [{
+        :find => "FilteredModule",
+        :filter => [ "bad_file.cfg" ]
+      }]
+    })
+    expect(install.match?("FilteredModule/good_file.cfg")).to be true
+    expect(install.match?("FilteredModule/bad_file.cfg")).to be false
+    expect(install.match?("FilteredModule/Parts/bad_file.cfg")).to be false
+  end
+end
+
+describe KerbalX::CkanReader do
+  before :each do
     @path = KerbalX.root(["test_env"])
     
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
 
-Bundler.setup 
+require "bundler"
+
+Bundler.setup
 require 'KerbalX'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Problem

As [noted on the forum](https://forum.kerbalspaceprogram.com/index.php?/topic/84389-kerbalxcom-craft-mission-sharing/&do=findComment&comment=3770540), KerbalX's mod part parsing code is missing some logic to handle CKAN metadata properly. Specifically, CKAN does *not* install **all** files in a ZIP; instead, the `install.file`, `install.find`, and `install.find_regexp` properties define what to unzip, and if there is no explicit `install` property, it defaults to extracting the folder named after the mod's identifier:

- https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#install

This is to handle things like bundled dependencies, where a download includes files that are borrowed from other mods, which CKAN prefers to install from their original source.

In the specific instance of APModpack, this led to a bundled copy of BDArmory that CKAN doesn't even install taking ownership of many BDArmory files on KerbalX craft pages in APModpack's name. For example:

- https://kerbalx.com/callsignblaze/Su-30-Varyate

Originally reported by @TheKurgan in KSP-CKAN/NetKAN#7841.

## Changes

- New class `InstallStanza` represents a single JSON object specifying a folder to install, optionally with filters
- New class `InstallStanzas` represents a whole `install` property, a JSON array of `InstallStanza` objects
- The `install` property is parsed when loading .ckan files
- The `InstallStanzas.match?` function is used to determine whether to parse a cfg file for part info
- Tests are added to `spec/lib/KerbalX/ckan_reader_spec.rb` to exercise these classes

This should fix the issue with APModpack and any other mods in a similar situation.

Tagging @Sujimichi because GitHub is delinquent in sending notifications for pull requests.